### PR TITLE
Update link text to include feature label in HelpTraySectionFeatures

### DIFF
--- a/src/components/HelpTraySectionFeatures.tsx
+++ b/src/components/HelpTraySectionFeatures.tsx
@@ -30,7 +30,9 @@ const HelpTraySectionFeatures: FC = () => {
 				<Text size="small">{feature.description}</Text>
 				{feature.link && (
 					<Text as="p" size="small">
-						<ExternalLink href={feature.link}>Learn more</ExternalLink>
+						<ExternalLink href={feature.link}>
+							Learn more about {feature.label}
+						</ExternalLink>
 					</Text>
 				)}
 			</View>


### PR DESCRIPTION
Reference the current feature in the link text

fixes #2 