### PR TITLE
Output correct progress % to screenreaders

### DIFF
--- a/src/components/SignupProgress.tsx
+++ b/src/components/SignupProgress.tsx
@@ -9,7 +9,7 @@ const SignupProgress = ({ status }: SignupProgressProps) => {
 
 	return (
 		<ProgressCircle
-			formatScreenReaderValue={(percent) => `${percent} percent`}
+			formatScreenReaderValue={({ valueNow }) => `${valueNow} percent`}
 			id="formProgress"
 			renderValue={({ valueNow }) => (
 				<span>

--- a/tests/components/SignupProgress.test.tsx
+++ b/tests/components/SignupProgress.test.tsx
@@ -1,0 +1,17 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import SignupProgress from "../../src/components/SignupProgress";
+
+describe("SignupProgress", () => {
+	it("renders a progress element with aria-valuetext containing current status", () => {
+		const status = 42;
+		render(<SignupProgress status={status} />);
+		const progress = screen.getByRole("progressbar");
+		expect(progress).toHaveAttribute(
+			"aria-valuetext",
+			expect.stringContaining(`${status}`),
+		);
+	});
+});


### PR DESCRIPTION
before

```
<progress max="100" value="100" aria-valuetext="Percent complete [object Object] percent"></progress>
```
after
```
<progress max="100" value="100" aria-valuetext="Percent complete 100 percent"></progress>
```

fixes #9 
