### PR TITLE
add pr management workflows

### DIFF
--- a/.github/rulesets/require-pr-main.json
+++ b/.github/rulesets/require-pr-main.json
@@ -1,0 +1,40 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/main"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "required_approving_review_count": 1
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "validate-pr-into-main"
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/.github/rulesets/require-pr-package.json
+++ b/.github/rulesets/require-pr-package.json
@@ -1,0 +1,35 @@
+{
+  "name": "Package branches (no-dash) policy",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/*"
+      ],
+      "exclude": [
+        "refs/heads/main",
+        "refs/heads/*-*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "validate-pr-prefixes"
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/.github/workflows/validate-pr-into-main.yml
+++ b/.github/workflows/validate-pr-into-main.yml
@@ -1,0 +1,45 @@
+name: validate-pr-into-main
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Fail if source branch is not allowed
+        shell: bash
+        run: |
+          BASE="${{ github.base_ref }}"
+          HEAD="${{ github.head_ref }}"
+          echo "Base: $BASE"
+          echo "Head: $HEAD"
+
+          if [[ "$BASE" != "main" ]]; then
+            echo "Not targeting main; skip."
+            exit 0
+          fi
+
+          # Gather package folder names
+          mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
+          echo "Package branches: ${PKGS[@]}"
+
+          # Check if HEAD is one of the packages
+          for pkg in "${PKGS[@]}"; do
+            if [[ "$HEAD" == "$pkg" ]]; then
+              echo "✅ Allowed: PR from package branch '$HEAD'"
+              exit 0
+            fi
+          done
+
+          # Check if HEAD starts with main-
+          if [[ "$HEAD" =~ ^main- ]]; then
+            echo "✅ Allowed: PR from branch '$HEAD' (main- prefix)"
+            exit 0
+          fi
+
+          echo "❌ Only PRs from package branches (${PKGS[*]}) or branches starting with 'main-' may target main."
+          exit 1

--- a/.github/workflows/validate-pr-into-main.yml
+++ b/.github/workflows/validate-pr-into-main.yml
@@ -27,7 +27,7 @@ jobs:
 
           # Gather package folder names
           if [ -d ./packages ]; then
-            mapfile -t PKGS < <(ls -1d ./packages/*/ | xargs -n 1 basename)
+            mapfile -t PKGS < <(ls -1d ./packages/*/ 2>/dev/null | xargs -n 1 basename)
           else
             PKGS=()
           fi

--- a/.github/workflows/validate-pr-into-main.yml
+++ b/.github/workflows/validate-pr-into-main.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr-into-main.yml
+++ b/.github/workflows/validate-pr-into-main.yml
@@ -27,7 +27,7 @@ jobs:
 
           # Gather package folder names
           if [ -d ./packages ]; then
-            mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
+            mapfile -t PKGS < <(ls -1d ./packages/*/ | xargs -n 1 basename)
           else
             PKGS=()
           fi

--- a/.github/workflows/validate-pr-into-main.yml
+++ b/.github/workflows/validate-pr-into-main.yml
@@ -42,7 +42,7 @@ jobs:
           done
 
           # Check if HEAD starts with main-
-          if [[ "$HEAD" =~ '^main-' ]]; then
+          if [[ "$HEAD" =~ ^"main-" ]]; then
             echo "✅ Allowed: PR from branch '$HEAD' (main- prefix)"
             exit 0
           fi

--- a/.github/workflows/validate-pr-into-main.yml
+++ b/.github/workflows/validate-pr-into-main.yml
@@ -24,7 +24,11 @@ jobs:
           fi
 
           # Gather package folder names
-          mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
+          if [ -d ./packages ]; then
+            mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
+          else
+            PKGS=()
+          fi
           echo "Package branches: ${PKGS[@]}"
 
           # Check if HEAD is one of the packages

--- a/.github/workflows/validate-pr-into-main.yml
+++ b/.github/workflows/validate-pr-into-main.yml
@@ -40,7 +40,7 @@ jobs:
           done
 
           # Check if HEAD starts with main-
-          if [[ "$HEAD" =~ ^main- ]]; then
+          if [[ "$HEAD" =~ '^main-' ]]; then
             echo "✅ Allowed: PR from branch '$HEAD' (main- prefix)"
             exit 0
           fi

--- a/.github/workflows/validate-pr-prefixes.yml
+++ b/.github/workflows/validate-pr-prefixes.yml
@@ -25,7 +25,7 @@ jobs:
             echo "No ./packages directory; skipping."
             exit 0
           else
-            mapfile -t PKGS < <(ls -1d ./packages/*/ 2>/dev/null | xargs -n 1 basename)
+            mapfile -t PKGS < <(find ./packages -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
           fi
 
           if [[ ${#PKGS[@]} -eq 0 ]]; then

--- a/.github/workflows/validate-pr-prefixes.yml
+++ b/.github/workflows/validate-pr-prefixes.yml
@@ -1,0 +1,56 @@
+name: validate-pr-prefixes
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Validate PR source branch prefix for package branches
+        shell: bash
+        run: |
+          BASE="${{ github.base_ref }}"
+          HEAD="${{ github.head_ref }}"
+          echo "Base: $BASE"
+          echo "Head: $HEAD"
+
+          # Gather package directory names (one level)
+          if [[ ! -d "./packages" ]]; then
+            echo "No ./packages directory; skipping."
+            exit 0
+          fi
+          mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
+
+          if [[ ${#PKGS[@]} -eq 0 ]]; then
+            echo "No packages found; skipping."
+            exit 0
+          fi
+
+          # Is the base branch one of the package names?
+          is_pkg_base="false"
+          for pkg in "${PKGS[@]}"; do
+            if [[ "$BASE" == "$pkg" ]]; then
+              is_pkg_base="true"
+              target_pkg="$pkg"
+              break
+            fi
+          done
+
+          if [[ "$is_pkg_base" != "true" ]]; then
+            echo "Base '$BASE' is not a package branch; skipping."
+            exit 0
+          fi
+
+          # Enforce prefix: HEAD must start with "<base>-"
+          required_prefix="${target_pkg}-"
+          if [[ "$HEAD" =~ ^${required_prefix} ]]; then
+            echo "✅ OK: head branch starts with '${required_prefix}'"
+            exit 0
+          fi
+
+          echo "❌ PRs into '${target_pkg}' must come from branches starting with '${required_prefix}'"
+          exit 1

--- a/.github/workflows/validate-pr-prefixes.yml
+++ b/.github/workflows/validate-pr-prefixes.yml
@@ -50,7 +50,7 @@ jobs:
 
           # Enforce prefix: HEAD must start with "<base>-"
           required_prefix="${target_pkg}-"
-          if [[ "$HEAD" =~ ^${required_prefix} ]]; then
+          if [[ "$HEAD" =~ ^"${required_prefix}" ]]; then
             echo "✅ OK: head branch starts with '${required_prefix}'"
             exit 0
           fi

--- a/.github/workflows/validate-pr-prefixes.yml
+++ b/.github/workflows/validate-pr-prefixes.yml
@@ -25,7 +25,7 @@ jobs:
             echo "No ./packages directory; skipping."
             exit 0
           else
-            mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
+            mapfile -t PKGS < <(ls -1d ./packages/*/ 2>/dev/null | xargs -n 1 basename)
           fi
 
           if [[ ${#PKGS[@]} -eq 0 ]]; then

--- a/.github/workflows/validate-pr-prefixes.yml
+++ b/.github/workflows/validate-pr-prefixes.yml
@@ -1,4 +1,6 @@
 name: validate-pr-prefixes
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/validate-pr-prefixes.yml
+++ b/.github/workflows/validate-pr-prefixes.yml
@@ -24,8 +24,9 @@ jobs:
           if [[ ! -d "./packages" ]]; then
             echo "No ./packages directory; skipping."
             exit 0
+          else
+            mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
           fi
-          mapfile -t PKGS < <(ls -1 ./packages | sed '/^$/d')
 
           if [[ ${#PKGS[@]} -eq 0 ]]; then
             echo "No packages found; skipping."


### PR DESCRIPTION
`@instructure.ai/shared-configs`

* Add workflows and rulesets to protect `main` and packages `@instructure.ai/*`
* `main` branch only accepts prs from bare package branches (e.g. `nutritionfacts`, `site`) or branches prefixed with `main-`
* Package branches only accept merges from branches prefixed with the package name (e.g. `nutritionfacts-`)